### PR TITLE
Fix version in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@v1
+            - uses: saucelabs/sauce-connect-action@v1.0.0
               with:
                 username: ${{ secrets.SAUCE_USERNAME }}
                 accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
`@v1` produced the following error:

An action could not be found at the URI 'https://api.github.com/repos/saucelabs/sauce-connect-action/tarball/v1'

