### PR TITLE
Revert "Bump base image to 4.6.2 from 4.5.4"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM saucelabs/sauce-connect:4.6.2
+FROM saucelabs/sauce-connect:4.5.4
 
 LABEL version="1.0.0"
 LABEL repository="http://github.com/saucelabs/sauce-connect-action"


### PR DESCRIPTION
Reverts saucelabs/sauce-connect-action#4

Per the comment [here](https://github.com/saucelabs/sauce-connect-action/pull/4#issuecomment-679791793), tag 4.6.2 [has not yet been published to docker hub for saucelabs/sauce-connect](https://hub.docker.com/r/saucelabs/sauce-connect/tags).  If this change could be reverted in the interim, that would be greatly appreciated 🙏 

Apologies for the run around!