### PR TITLE
Add retries and `retryTimeout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Sauce Connect Proxy GitHub Action
-=================================
+# Sauce Connect Proxy GitHub Action
 
 A GitHub action to launch Sauce Connect Proxy.
 
@@ -14,113 +13,151 @@ jobs:
             # ...
             - uses: saucelabs/sauce-connect-action@master
               with:
-                username: ${{ secrets.SAUCE_USERNAME }}
-                accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-                tunnelIdentifier: github-action-tunnel
-                scVersion: 4.6.2
+                  username: ${{ secrets.SAUCE_USERNAME }}
+                  accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+                  tunnelIdentifier: github-action-tunnel
+                  scVersion: 4.6.2
             # ...
 ```
 
 ## Inputs
 
 ### `username`:
+
 **Required** Sauce Labs user name.
 
 ### `accesskey`:
+
 **Required** Sauce Labs API Key.
 
 ### `cainfo`:
+
 CA certificate bundle to use for verifying REST connections. (default "/usr/local/etc/openssl/cert.pem")
 
 ### `capath`:
+
 Directory of CA certs to use for verifying REST connections. (default "/etc/ssl/certs")
 
 ### `configFile`:
+
 Path to YAML config file. Please refer to https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Command+Line +Reference for a sample configuration file.
 
 ### `directDomains`:
-Comma-separated list of domains. Requests whose host matches one of these will be relayed directly through the  internet, instead of through the tunnel.
+
+Comma-separated list of domains. Requests whose host matches one of these will be relayed directly through the internet, instead of through the tunnel.
 
 ### `dns`:
-"Use specified name server. To specify multiple servers, separate them with comma. Use IP addresses, optionally  with a port number, the two separated by a colon. Example: --dns 8.8.8.8,8.8.4.4:53"
+
+"Use specified name server. To specify multiple servers, separate them with comma. Use IP addresses, optionally with a port number, the two separated by a colon. Example: --dns 8.8.8.8,8.8.4.4:53"
 
 ### `doctor`:
+
 Perform checks to detect possible misconfiguration or problems.
 
 ### `fastFailRegexps`:
-Comma-separated list of regular expressions. Requests matching one of these will get dropped instantly and will  not go through the tunnel.
+
+Comma-separated list of regular expressions. Requests matching one of these will get dropped instantly and will not go through the tunnel.
 
 ### `logStats`:
+
 Log statistics about HTTP traffic every <seconds>.
 
 ### `maxLogsize`:
+
 Rotate logfile after reaching <bytes> size. Disabled by default.
 
 ### `maxMissedAcks`:
+
 The maximum amount of keepalive acks that can be missed before the client will trigger a reconnect. (default 30)
 
 ### `metricsAddress`:
+
 'host:port for the internal web server used to expose client side metrics. (default "localhost:8888")'
 
 ### `noAutodetect`:
+
 Disable the autodetection of proxy settings.
 
 ### `noProxyCaching`:
+
 Disable caching in Sauce Connect. All requests will be sent through the tunnel.
 
 ### `noRemoveCollidingTunnels`:
+
 Don't remove identified tunnels with the same name, or any other default tunnels if this is a default tunnel. Jobs will be distributed between these tunnels, enabling load balancing and high availability. By default, colliding tunnels will be removed when Sauce Connect is starting up.
 
 ### `noSSLBumpDomains`:
+
 Comma-separated list of domains. Requests whose host matches one of these will not be SSL re-encrypted.
 
 ### `pac`:
+
 Proxy autoconfiguration. Can be an http(s) or local file:// (absolute path only) URI.
 
 ### `proxy`:
+
 Proxy host and port that Sauce Connect should use to connect to the Sauce Labs cloud.
 
 ### `proxyTunnel`:
+
 Use the proxy configured with -p for the tunnel connection.
 
 ### `proxyUserpwd`:
+
 Username and password required to access the proxy configured with -p.
 
 ### `restUrl`:
-'Advanced feature: Connect to Sauce REST API at alternative URL. Use only if directed to do so by Sauce Labs  support. (default "https://saucelabs.com/rest/v1")'
+
+'Advanced feature: Connect to Sauce REST API at alternative URL. Use only if directed to do so by Sauce Labs support. (default "https://saucelabs.com/rest/v1")'
 
 ### `scproxyPort`:
+
 Port on which scproxy will be listening.
 
 ### `scproxyReadLimit`:
+
 Rate limit reads in scproxy to X bytes per second. This option can be used to adjust local network transfer rate in order not to overload the tunnel connection.
 
 ### `scproxyWriteLimit`:
+
 Rate limit writes in scproxy to X bytes per second. This option can be used to adjust local network transfer rate in order not to overload the tunnel connection.
 
 ### `sePort`:
+
 Port on which Sauce Connect's Selenium relay will listen for requests. Selenium commands reaching Connect on this port will be relayed to Sauce Labs securely and reliably through Connect's tunnel (default 4445)
 
 ### `sharedTunnel`:
+
 Let sub-accounts of the tunnel owner use the tunnel if requested.
 
 ### `tunnelCainfo`:
+
 CA certificate bundle to use for verifying tunnel connections. (default "/usr/local/etc/openssl/cert.pem")
 
 ### `tunnelCapath`:
+
 Directory of CA certs to use for verifying tunnel connections. (default "/etc/ssl/certs")
 
 ### `tunnelCert`:
+
 'Specify certificate to use for the tunnel connection, either public or private. Default: private. (default "private")'
 
 ### `tunnelDomains`:
+
 Inverse of '--direct-domains'. Only requests for domains in this list will be sent through the tunnel. Overrides '--direct-domains'.
 
 ### `tunnelIdentifier`:
+
 Don't automatically assign jobs to this tunnel. Jobs will use it only by explicitly providing the right identifier.
 
 ### `verbose`:
+
 Enable verbose logging. Can be used up to two times. (default "true")
 
 ### `scVersion`:
+
 Version of the saucelabs/sauce-connect docker image.
+
+### `retryTimeout`:
+
+Do not retry if this amount of seconds has passed since starting. (default: "0")

--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ Version of the saucelabs/sauce-connect docker image.
 
 ### `retryTimeout`:
 
-Do not retry if this amount of seconds has passed since starting. (default: "0")
+Do not retry if this amount of minutes has passed since starting. (default: "10")

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,6 @@ inputs:
     verbose:
         description: Enable verbose logging. Can be used up to two times.
         required: false
-        default: 'true'
     scVersion:
         description: Version of the saucelabs/sauce-connect docker image.
         required: false

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ name: 'Sauce Connect Proxy Action'
 description: 'A GitHub action to launch Sauce Connect Proxy'
 author: Christian Bromann
 branding:
-  icon: server
-  color: red
+    icon: server
+    color: red
 inputs:
     username:
         description: Sauce Labs user name.
@@ -25,7 +25,7 @@ inputs:
         description: Comma-separated list of domains. Requests whose host matches one of these will be relayed directly through the internet, instead of through the tunnel.
         required: false
     dns:
-        description: "Use specified name server. To specify multiple servers, separate them with comma. Use IP addresses, optionally with a port number, the two separated by a colon. Example: --dns 8.8.8.8,8.8.4.4:53"
+        description: 'Use specified name server. To specify multiple servers, separate them with comma. Use IP addresses, optionally with a port number, the two separated by a colon. Example: --dns 8.8.8.8,8.8.4.4:53'
         required: false
     doctor:
         description: Perform checks to detect possible misconfiguration or problems.
@@ -105,12 +105,16 @@ inputs:
     verbose:
         description: Enable verbose logging. Can be used up to two times.
         required: false
-        default: "true"
+        default: 'true'
     scVersion:
         description: Version of the saucelabs/sauce-connect docker image.
         required: false
-        default: "4.6.2"
+        default: '4.6.2'
+    retryTimeout:
+        description: Do not retry if this amount of seconds has passed since starting.
+        required: false
+        default: '0'
 runs:
-  using: 'node12'
-  main: 'dist/main/index.js'
-  post: 'dist/post/index.js'
+    using: 'node12'
+    main: 'dist/main/index.js'
+    post: 'dist/post/index.js'

--- a/action.yml
+++ b/action.yml
@@ -111,9 +111,9 @@ inputs:
         required: false
         default: '4.6.2'
     retryTimeout:
-        description: Do not retry if this amount of seconds has passed since starting.
+        description: Do not retry if this amount of minutes has passed since starting.
         required: false
-        default: '0'
+        default: '10'
 runs:
     using: 'node12'
     main: 'dist/main/index.js'

--- a/src/exec-and-return.ts
+++ b/src/exec-and-return.ts
@@ -1,0 +1,16 @@
+import {exec} from '@actions/exec'
+
+export async function execAndReturn(
+    commandLine: string,
+    args?: string[]
+): Promise<string> {
+    let output = ''
+    await exec(commandLine, args, {
+        listeners: {
+            stdout: (data: Buffer) => {
+                output += data.toString()
+            }
+        }
+    })
+    return output
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import {start} from './start'
 const retryDelays = [1, 1, 1, 2, 3, 4, 5, 10, 20, 40, 60].map(a => a * 1000)
 
 async function run(): Promise<void> {
-    const retryTimeout = parseInt(getInput('retryTimeout') || '0', 10) * 1000
+    const retryTimeout = parseInt(getInput('retryTimeout'), 10) * 1000
     const startTime = Date.now()
 
     for (let i = 0; ; i++) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import {getInput, saveState, setFailed, warning} from '@actions/core'
-import {start} from './start'
+import {startContainer} from './start-container'
 
 const retryDelays = [1, 1, 1, 2, 3, 4, 5, 10, 20, 40, 60].map(a => a * 1000)
 
@@ -9,7 +9,7 @@ async function run(): Promise<void> {
 
     for (let i = 0; ; i++) {
         try {
-            const containerId = await start()
+            const containerId = await startContainer()
             saveState('containerId', containerId)
             return
         } catch (e) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import {startContainer} from './start-container'
 const retryDelays = [1, 1, 1, 2, 3, 4, 5, 10, 20, 40, 60].map(a => a * 1000)
 
 async function run(): Promise<void> {
-    const retryTimeout = parseInt(getInput('retryTimeout'), 10) * 1000
+    const retryTimeout = parseInt(getInput('retryTimeout'), 10) * 1000 * 60
     const startTime = Date.now()
 
     for (let i = 0; ; i++) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function run(): Promise<void> {
             }
             const delay = retryDelays[Math.min(retryDelays.length - 1, i)]
             warning(
-                `Error occurred on attempt ${i}. Retrying in ${delay} ms...`
+                `Error occurred on attempt ${i + 1}. Retrying in ${delay} ms...`
             )
             await new Promise(resolve => setTimeout(() => resolve(), delay))
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,82 +1,10 @@
-import {getInput, info, saveState, setFailed} from '@actions/core'
-import {exec} from '@actions/exec'
-import {join} from 'path'
-import {tmpdir} from 'os'
-import {promises} from 'fs'
-import {wait} from './wait'
-import optionMappingJson from './option-mapping.json'
-
-const LOG_FILE = '/srv/sauce-connect.log'
-const PID_FILE = '/srv/sauce-connect.pid'
-const READY_FILE = '/opt/sauce-connect-action/sc.ready'
-
-type OptionMapping = {
-    actionOption: string
-    dockerOption: string
-    required?: boolean
-    flag?: boolean
-}
-const optionMappings: OptionMapping[] = optionMappingJson
-
-function buildOptions(): string[] {
-    const params = [
-        `--logfile=${LOG_FILE}`,
-        `--pidfile=${PID_FILE}`,
-        `--readyfile=${READY_FILE}`,
-        `--verbose`
-    ]
-
-    for (const optionMapping of optionMappings) {
-        const input = getInput(optionMapping.actionOption, {
-            required: optionMapping.required
-        })
-
-        if (input === '') {
-            // user input nothing for this option
-        } else if (optionMapping.flag) {
-            // for flag options like --doctor option
-            params.push(`--${optionMapping.dockerOption}`)
-        } else {
-            params.push(`--${optionMapping.dockerOption}=${input}`)
-        }
-    }
-    return params
-}
+import {saveState, setFailed} from '@actions/core'
+import {start} from './start'
 
 async function run(): Promise<void> {
-    const DIR_IN_HOST = await promises.mkdtemp(
-        join(tmpdir(), `sauce-connect-action`)
-    )
-    const containerVersion = getInput('scVersion')
-    const containerName = `saucelabs/sauce-connect:${containerVersion}`
-    try {
-        await exec('docker', ['pull', containerName])
-        let containerId = ''
-        await exec(
-            'docker',
-            [
-                'run',
-                '--network=host',
-                '--detach',
-                '-v',
-                `${DIR_IN_HOST}:/opt/sauce-connect-action`,
-                '--rm',
-                containerName
-            ].concat(buildOptions()),
-            {
-                listeners: {
-                    stdout: (data: Buffer) => {
-                        containerId += data.toString()
-                    }
-                }
-            }
-        )
-        saveState('containerId', containerId.trim())
-        await wait(DIR_IN_HOST)
-        info('SC ready')
-    } catch (error) {
-        setFailed(error.message)
-    }
+    const containerId = await start()
+    saveState('containerId', containerId)
 }
 
-run()
+// eslint-disable-next-line github/no-then
+run().catch(error => setFailed(error.message))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,29 @@
-import {saveState, setFailed} from '@actions/core'
+import {getInput, saveState, setFailed, warning} from '@actions/core'
 import {start} from './start'
 
+const retryDelays = [1, 1, 1, 2, 3, 4, 5, 10, 20, 40, 60].map(a => a * 1000)
+
 async function run(): Promise<void> {
-    const containerId = await start()
-    saveState('containerId', containerId)
+    const retryTimeout = parseInt(getInput('retryTimeout') || '0', 10) * 1000
+    const startTime = Date.now()
+
+    for (let i = 0; ; i++) {
+        try {
+            const containerId = await start()
+            saveState('containerId', containerId)
+            return
+        } catch (e) {
+            if (Date.now() - startTime >= retryTimeout) {
+                break
+            }
+            const delay = retryDelays[Math.min(retryDelays.length - 1, i)]
+            warning(
+                `Error occurred on attempt ${i}. Retrying in ${delay} ms...`
+            )
+            await new Promise(resolve => setTimeout(() => resolve(), delay))
+        }
+        throw new Error('Timed out')
+    }
 }
 
 // eslint-disable-next-line github/no-then

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ async function run(): Promise<void> {
             )
             await new Promise(resolve => setTimeout(() => resolve(), delay))
         }
-        throw new Error('Timed out')
     }
+    throw new Error('Timed out')
 }
 
 // eslint-disable-next-line github/no-then

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,5 +1,5 @@
-import {getState, info, warning, setFailed} from '@actions/core'
-import {exec} from '@actions/exec'
+import {getState, warning, setFailed} from '@actions/core'
+import {stopContainer} from './stop-container'
 
 async function run(): Promise<void> {
     const containerId = getState('containerId')
@@ -10,13 +10,8 @@ async function run(): Promise<void> {
         return
     }
 
-    try {
-        info(`Trying to stop the docker container with ID ${containerId}...`)
-        await exec('docker', ['container', 'stop', containerId])
-        info('Done.')
-    } catch (error) {
-        setFailed(error.message)
-    }
+    await stopContainer(containerId)
 }
 
-run()
+// eslint-disable-next-line github/no-then
+run().catch(error => setFailed(error.message))

--- a/src/start-container.ts
+++ b/src/start-container.ts
@@ -82,7 +82,7 @@ export async function startContainer(): Promise<string> {
     } finally {
         if (isDebug()) {
             try {
-                const log = promises.readFile(
+                const log = await promises.readFile(
                     join(DIR_IN_HOST, 'sauce-connect.log'),
                     {
                         encoding: 'utf-8'

--- a/src/start-container.ts
+++ b/src/start-container.ts
@@ -26,9 +26,12 @@ function buildOptions(): string[] {
     const params = [
         `--logfile=${LOG_FILE}`,
         `--pidfile=${PID_FILE}`,
-        `--readyfile=${READY_FILE}`,
-        `--verbose`
+        `--readyfile=${READY_FILE}`
     ]
+
+    if (isDebug()) {
+        params.push('--verbose')
+    }
 
     for (const optionMapping of optionMappings) {
         const input = getInput(optionMapping.actionOption, {

--- a/src/start-container.ts
+++ b/src/start-container.ts
@@ -44,7 +44,7 @@ function buildOptions(): string[] {
     return params
 }
 
-export async function start(): Promise<string> {
+export async function startContainer(): Promise<string> {
     const DIR_IN_HOST = await promises.mkdtemp(
         join(tmpdir(), `sauce-connect-action`)
     )

--- a/src/start.ts
+++ b/src/start.ts
@@ -74,9 +74,10 @@ export async function start(): Promise<string> {
     containerId = containerId.trim()
     try {
         await wait(DIR_IN_HOST)
-        info('SC ready')
-    } finally {
+    } catch (e) {
         await stopContainer(containerId)
+        throw e
     }
+    info('SC ready')
     return containerId
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,82 @@
+import {getInput, info} from '@actions/core'
+import {exec} from '@actions/exec'
+import {join} from 'path'
+import {tmpdir} from 'os'
+import {promises} from 'fs'
+import {wait} from './wait'
+import optionMappingJson from './option-mapping.json'
+import {stopContainer} from './stop-container'
+
+const LOG_FILE = '/srv/sauce-connect.log'
+const PID_FILE = '/srv/sauce-connect.pid'
+const READY_FILE = '/opt/sauce-connect-action/sc.ready'
+
+type OptionMapping = {
+    actionOption: string
+    dockerOption: string
+    required?: boolean
+    flag?: boolean
+}
+const optionMappings: OptionMapping[] = optionMappingJson
+
+function buildOptions(): string[] {
+    const params = [
+        `--logfile=${LOG_FILE}`,
+        `--pidfile=${PID_FILE}`,
+        `--readyfile=${READY_FILE}`,
+        `--verbose`
+    ]
+
+    for (const optionMapping of optionMappings) {
+        const input = getInput(optionMapping.actionOption, {
+            required: optionMapping.required
+        })
+
+        if (input === '') {
+            // user input nothing for this option
+        } else if (optionMapping.flag) {
+            // for flag options like --doctor option
+            params.push(`--${optionMapping.dockerOption}`)
+        } else {
+            params.push(`--${optionMapping.dockerOption}=${input}`)
+        }
+    }
+    return params
+}
+
+export async function start(): Promise<string> {
+    const DIR_IN_HOST = await promises.mkdtemp(
+        join(tmpdir(), `sauce-connect-action`)
+    )
+    const containerVersion = getInput('scVersion')
+    const containerName = `saucelabs/sauce-connect:${containerVersion}`
+    await exec('docker', ['pull', containerName])
+    let containerId = ''
+    await exec(
+        'docker',
+        [
+            'run',
+            '--network=host',
+            '--detach',
+            '-v',
+            `${DIR_IN_HOST}:/opt/sauce-connect-action`,
+            '--rm',
+            containerName
+        ].concat(buildOptions()),
+        {
+            listeners: {
+                stdout: (data: Buffer) => {
+                    containerId += data.toString()
+                }
+            }
+        }
+    )
+    containerId = containerId.trim()
+    try {
+        await wait(DIR_IN_HOST)
+        info('SC ready')
+    } finally {
+        await stopContainer(containerId)
+    }
+    return containerId
+}

--- a/src/stop-container.ts
+++ b/src/stop-container.ts
@@ -1,5 +1,5 @@
+import {info} from '@actions/core'
 import {exec} from '@actions/exec'
-import {info} from 'console'
 
 export async function stopContainer(containerId: string): Promise<void> {
     info(`Trying to stop the docker container with ID ${containerId}...`)

--- a/src/stop-container.ts
+++ b/src/stop-container.ts
@@ -7,13 +7,12 @@ export async function stopContainer(containerId: string): Promise<void> {
     const running =
         (
             await execAndReturn('docker', [
-                'container',
-                'inspect',
+                'ps',
+                '-q',
                 '-f',
-                '{{.State.Running}}',
-                containerId
+                `id=${containerId}`
             ])
-        ).trim() === 'true'
+        ).trim() !== ''
 
     if (running) {
         await exec('docker', ['container', 'stop', containerId])

--- a/src/stop-container.ts
+++ b/src/stop-container.ts
@@ -1,8 +1,24 @@
 import {info} from '@actions/core'
 import {exec} from '@actions/exec'
+import {execAndReturn} from './exec-and-return'
 
 export async function stopContainer(containerId: string): Promise<void> {
     info(`Trying to stop the docker container with ID ${containerId}...`)
-    await exec('docker', ['container', 'stop', containerId])
+    const running =
+        (
+            await execAndReturn('docker', [
+                'container',
+                'inspect',
+                '-f',
+                '{{.State.Running}}',
+                containerId
+            ])
+        ).trim() === 'true'
+
+    if (running) {
+        await exec('docker', ['container', 'stop', containerId])
+    } else {
+        info('Container not running.')
+    }
     info('Done.')
 }

--- a/src/stop-container.ts
+++ b/src/stop-container.ts
@@ -1,0 +1,8 @@
+import {exec} from '@actions/exec'
+import {info} from 'console'
+
+export async function stopContainer(containerId: string): Promise<void> {
+    info(`Trying to stop the docker container with ID ${containerId}...`)
+    await exec('docker', ['container', 'stop', containerId])
+    info('Done.')
+}


### PR DESCRIPTION
I haven't tested this yet (but not really sure how), and there aren't any unit tests either. Let me know if you'd like unit tests and I'll add some.

This adds retries, where the delay gets larger each time, and a retry is not scheduled if more than `retryTimeout` seconds has passed. I'm hoping this will be useful when the concurrency limit is reached. When that happens I'm assuming the ready file isn't created?