### PR TITLE
docs: Encourage use of v1 instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@master
+            - uses: saucelabs/sauce-connect-action@v1
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
Knowing that every pleb will copy-paste this example as-is,
I'd recommend encouraging use of v1 (e.g. latest `v1.x.x` tag on this repo),
instead of `master`, so that if one day you need to make a significant change
to the format somehow or add/change required options, that you will do so
in a SemVer compliant way and that it won't break thousands of projects
already using the action.