### PR TITLE
Export host dir as an environment variable

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1685,6 +1685,7 @@ function buildOptions() {
 function startContainer() {
     return __awaiter(this, void 0, void 0, function* () {
         const DIR_IN_HOST = yield fs_1.promises.mkdtemp(path_1.join(os_1.tmpdir(), `sauce-connect-action`));
+        core_1.exportVariable('SAUCE_CONNECT_DIR_IN_HOST', DIR_IN_HOST);
         const containerVersion = core_1.getInput('scVersion');
         const containerName = `saucelabs/sauce-connect:${containerVersion}`;
         yield exec_1.exec('docker', ['pull', containerName]);

--- a/src/start-container.ts
+++ b/src/start-container.ts
@@ -1,4 +1,4 @@
-import {getInput, info, debug, isDebug, warning} from '@actions/core'
+import {getInput, info, debug, isDebug, warning, exportVariable} from '@actions/core'
 import {exec} from '@actions/exec'
 import {join} from 'path'
 import {tmpdir} from 'os'
@@ -54,6 +54,7 @@ export async function startContainer(): Promise<string> {
     const DIR_IN_HOST = await promises.mkdtemp(
         join(tmpdir(), `sauce-connect-action`)
     )
+    exportVariable('SAUCE_CONNECT_DIR_IN_HOST', DIR_IN_HOST)
     const containerVersion = getInput('scVersion')
     const containerName = `saucelabs/sauce-connect:${containerVersion}`
     await exec('docker', ['pull', containerName])


### PR DESCRIPTION
I was looking for a way to store the logs as an artifact (as per #14) but as far as I could tell the temporary directory name `DIR_IN_HOST` wasn't available outside of the start script.

This PR exports an environment variable `SAUCE_CONNECT_DIR_IN_HOST` (perhaps the name could be improved) which can then be used to store the log file in a workflow:

```
    - uses: actions/upload-artifact@v2
      with:
        name: sauce-connect-log
        path: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}/sauce-connect.log
```

I've tested this out on the [HEPData](https://github.com/HEPData/hepdata) repo at https://github.com/HEPData/hepdata/runs/2904966154?check_suite_focus=true 

(NB: I've just realised that you could probably achieve the same with wildcards in the upload-artifact path but I think this PR makes it easier to do.)