### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@v2
+            - uses: actions/checkout@v3  # reference files in the current repository
+            - uses: saucelabs/sauce-connect-action@v2  # or use the latest version with @main
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -84,7 +85,8 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: saucelabs/sauce-connect-action@v3
+            - uses: actions/checkout@v3  # reference files in the current repository
+            - uses: saucelabs/sauce-connect-action@v2  # or use the latest version with @main
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5372,13 +5372,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.wait = void 0;
 const fs_1 = __webpack_require__(747);
+const timeoutSeconds = 60;
 function wait(dir) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
                 watcher.close();
-                reject(new Error('timeout: SC was not ready even after we wait 45 secs'));
-            }, 45 * 1000);
+                reject(new Error(`timeout: SC was not ready even after we wait ${timeoutSeconds} secs`));
+            }, timeoutSeconds * 1000);
             const watcher = fs_1.watch(dir, (eventType, filename) => {
                 if (filename !== 'sc.ready') {
                     return;


### PR DESCRIPTION
Ensure `uses: actions/checkout@v3` is added to all examples. This is required to use config files from the project calling Sauce Connect action.