### PR TITLE
Add error message for missing logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
         steps:
             # ...
             - uses: actions/checkout@v3  # reference files in the current repository
-            - uses: saucelabs/sauce-connect-action@v2  # or use the latest version with @main
+            - uses: saucelabs/sauce-connect-action@v2
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -86,7 +86,7 @@ jobs:
         steps:
             # ...
             - uses: actions/checkout@v3  # reference files in the current repository
-            - uses: saucelabs/sauce-connect-action@v2  # or use the latest version with @main
+            - uses: saucelabs/sauce-connect-action@v2
               with:
                   username: ${{ secrets.SAUCE_USERNAME }}
                   accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5312,7 +5312,7 @@ function startSc() {
                 }
                 catch (e2) {
                     core_1.warning(`Unable to access Sauce connect log file: ${e2}.
-                This could be cause by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
+                This could be caused by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
                 Please verify your configuration and ensure any referenced files are available.`);
                 }
             }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5304,10 +5304,17 @@ function startSc() {
         }
         finally {
             if (errorOccurred || core_1.isDebug()) {
-                const log = fs_1.readFileSync(LOG_FILE, {
-                    encoding: 'utf-8'
-                });
-                (errorOccurred ? core_1.warning : core_1.debug)(`Sauce connect log: ${log}`);
+                try {
+                    const log = fs_1.readFileSync(LOG_FILE, {
+                        encoding: 'utf-8'
+                    });
+                    (errorOccurred ? core_1.warning : core_1.debug)(`Sauce connect log: ${log}`);
+                }
+                catch (e2) {
+                    core_1.warning(`Unable to access Sauce connect log file: ${e2}.
+                This could be cause by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
+                Please verify your configuration and ensure any referenced files are available.`);
+                }
             }
         }
     });

--- a/src/start-sc.ts
+++ b/src/start-sc.ts
@@ -1,13 +1,13 @@
-import {debug, getInput, isDebug, warning} from '@actions/core'
-import {which} from '@actions/io'
-import {spawn} from 'child_process'
-import {info} from 'console'
-import {mkdtempSync, readFileSync} from 'fs'
-import {tmpdir} from 'os'
-import {dirname, join} from 'path'
+import { debug, getInput, isDebug, warning } from '@actions/core'
+import { which } from '@actions/io'
+import { spawn } from 'child_process'
+import { info } from 'console'
+import { mkdtempSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
 import optionMappingJson from './option-mapping.json'
-import {stopSc} from './stop-sc'
-import {wait} from './wait'
+import { stopSc } from './stop-sc'
+import { wait } from './wait'
 
 const tmp = mkdtempSync(join(tmpdir(), `sauce-connect-action`))
 const LOG_FILE = join(tmp, 'sauce-connect.log')
@@ -74,11 +74,16 @@ export async function startSc(): Promise<string> {
         throw e
     } finally {
         if (errorOccurred || isDebug()) {
-            const log = readFileSync(LOG_FILE, {
-                encoding: 'utf-8'
-            })
-
-            ;(errorOccurred ? warning : debug)(`Sauce connect log: ${log}`)
+            try {
+                const log = readFileSync(LOG_FILE, {
+                    encoding: 'utf-8'
+                })
+                    ; (errorOccurred ? warning : debug)(`Sauce connect log: ${log}`)
+            } catch (e2) {
+                warning(`Unable to access Sauce connect log file: ${e2}.
+                This could be cause by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
+                Please verify your configuration and ensure any referenced files are available.`)
+            }
         }
     }
 }

--- a/src/start-sc.ts
+++ b/src/start-sc.ts
@@ -81,7 +81,7 @@ export async function startSc(): Promise<string> {
                     ; (errorOccurred ? warning : debug)(`Sauce connect log: ${log}`)
             } catch (e2) {
                 warning(`Unable to access Sauce connect log file: ${e2}.
-                This could be cause by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
+                This could be caused by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
                 Please verify your configuration and ensure any referenced files are available.`)
             }
         }


### PR DESCRIPTION
When Sauce Connect exits before the log file is created, there is no additional info on why Sauce Connect did not start.

Add a descriptive error message indicating that the error is likely caused by incorrect SC or GHA config:

```
Warning: Unable to access Sauce connect log file: Error: ENOENT: no such file or directory, open '/tmp/sauce-connect-action1NxO8w/sauce-connect.log'.
    This could be caused by an error with the Sauce Connect or Github Action configuration that prevented Sauce Connect from starting up.
    Please verify your configuration and ensure any referenced files are available.
```